### PR TITLE
Allow the creation of SelfAttestedClaims

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "devDependencies": {
     "@types/jasmine": "^3.6.9",
+    "@types/node": "^15.12.2",
     "jasmine": "^3.7.0",
     "prettier": "^2.2.1",
     "ts-node": "^9.1.1",

--- a/spec/integration/GenerateSelfAttestedClaimSpec.ts
+++ b/spec/integration/GenerateSelfAttestedClaimSpec.ts
@@ -1,0 +1,59 @@
+import "jasmine";
+import { Wallet } from "ethers";
+
+import AttestationRequest from "../../src/AttestationRequest";
+import Claim from "../../src/Claim";
+import ClaimType from "../../src/ClaimType";
+import SelfAttestedClaim from "../../src/SelfAttestedClaim";
+
+describe("generate a self attested claim", () => {
+  it("results in a valid SelfAttestedClaim", async () => {
+    const attester = Wallet.createRandom();
+    const claimer = Wallet.createRandom();
+    const kycLevel = "basic+liveness";
+
+    // Generate a claim type
+    const claimType = ClaimType.build(kycLevel);
+
+    // Create a claim with our data
+    const properties = {
+      residential_address_country: "NZ",
+      date_of_birth: "1990-01-01",
+      full_name: "JOHN CITIZEN",
+      identification_document_country: "NZ",
+      identification_document_number: "00000000",
+      identification_document_type: "passport",
+      liveness: true,
+    };
+
+    const claim = new Claim(claimType, properties, claimer.address);
+
+    // Generate an AttestationRequest
+    const request = AttestationRequest.fromClaim(claim);
+
+    // Run the expectations: all fields are defined && valid
+    expect(request.claim).toBeDefined();
+    expect(request.claimHashTree).toBeDefined();
+    expect(request.claimTypeHash).toBeDefined();
+    expect(request.rootHash).toBeDefined();
+    expect(request.validateWithoutSignature()).toBeTrue();
+
+    // Generate the self attested claim from the request
+    const selfAttestedClaim = SelfAttestedClaim.fromRequest(
+      request,
+      attester.address,
+      kycLevel
+    );
+
+    // Generate the hash and sign it
+    const hashToSign = selfAttestedClaim.generateHash();
+    selfAttestedClaim.attesterSignature = await attester.signMessage(
+      hashToSign
+    );
+
+    // Run the expectations: the claim has complete integrity and is correctly
+    // signed
+    expect(selfAttestedClaim.verifyIntegrity()).toBeTrue();
+    expect(selfAttestedClaim.verifySignature()).toBeTrue();
+  });
+});

--- a/spec/unit/SelfAttestedClaim/SelfAttestedClaimSpec.ts
+++ b/spec/unit/SelfAttestedClaim/SelfAttestedClaimSpec.ts
@@ -1,0 +1,164 @@
+import "jasmine";
+import { Wallet } from "ethers";
+
+import AttestationRequest from "../../../src/AttestationRequest";
+import Claim from "../../../src/Claim";
+import ClaimType from "../../../src/ClaimType";
+import SelfAttestedClaim from "../../../src/SelfAttestedClaim";
+
+import { Byte } from "../../../src/types";
+
+const buildClaim = (address?: string) => {
+  const kycLevel = "basic+liveness";
+
+  const claimType = ClaimType.build(kycLevel);
+
+  const properties = {
+    residential_address_country: "NZ",
+    date_of_birth: "1990-01-01",
+    full_name: "JOHN CITIZEN",
+    identification_document_country: "NZ",
+    identification_document_number: "00000000",
+    identification_document_type: "passport",
+    liveness: true,
+  };
+
+  return new Claim(claimType, properties, address);
+};
+
+const buildSelfAttestedClaim = (attesterAddress?: string) => {
+  const kycLevel = "basic+liveness";
+  const attester = attesterAddress || Wallet.createRandom().address;
+  const claimerAddress = Wallet.createRandom().address;
+  const claim = buildClaim(claimerAddress);
+  const request = AttestationRequest.fromClaim(claim);
+
+  return SelfAttestedClaim.fromRequest(request, attester, kycLevel);
+};
+
+describe("fromRequest", () => {
+  it("requires a claim owner", () => {
+    const kycLevel = "basic+liveness";
+    const attesterAddress = Wallet.createRandom().address;
+    const claim = buildClaim();
+    const request = AttestationRequest.fromClaim(claim);
+
+    const fn = () =>
+      SelfAttestedClaim.fromRequest(request, attesterAddress, kycLevel);
+
+    expect(fn).toThrowError();
+  });
+
+  it("requires a valid attestation request", () => {
+    const kycLevel = "basic+liveness";
+    const attesterAddress = Wallet.createRandom().address;
+    const claimerAddress = Wallet.createRandom().address;
+    const claim = buildClaim(claimerAddress);
+    const request = AttestationRequest.fromClaim(claim);
+    request.rootHash = "0x0";
+
+    const fn = () =>
+      SelfAttestedClaim.fromRequest(request, attesterAddress, kycLevel);
+
+    expect(fn).toThrowError();
+  });
+
+  it("requires the claim type corresponding to the claim", () => {
+    const kycLevel = "plus+liveness";
+    const attesterAddress = Wallet.createRandom().address;
+    const claimerAddress = Wallet.createRandom().address;
+    const claim = buildClaim(claimerAddress);
+    const request = AttestationRequest.fromClaim(claim);
+
+    const fn = () =>
+      SelfAttestedClaim.fromRequest(request, attesterAddress, kycLevel);
+
+    expect(fn).toThrowError();
+  });
+
+  it("converts the country of residence, country of ID issuance and KYC level", () => {
+    const kycLevel = "basic+liveness";
+    const attesterAddress = Wallet.createRandom().address;
+    const claimerAddress = Wallet.createRandom().address;
+    const claim = buildClaim(claimerAddress);
+    const request = AttestationRequest.fromClaim(claim);
+
+    const selfAttestedClaim = SelfAttestedClaim.fromRequest(
+      request,
+      attesterAddress,
+      kycLevel
+    );
+
+    expect(selfAttestedClaim.countryOfResidence).toBeInstanceOf(Byte);
+    expect(selfAttestedClaim.countryOfResidence.value).toBeInstanceOf(Number);
+    expect(selfAttestedClaim.countryOfIDIssuance).toBeInstanceOf(Byte);
+    expect(selfAttestedClaim.countryOfIDIssuance.value).toBeInstanceOf(Number);
+    expect(selfAttestedClaim.kycType).toBeInstanceOf(Byte);
+    expect(selfAttestedClaim.kycType.value).toBeInstanceOf(Number);
+  });
+});
+
+describe("verifyIntegrity", () => {
+  it("is true for valid selfAttestedClaims", () => {
+    const selfAttestedClaim = buildSelfAttestedClaim();
+
+    expect(selfAttestedClaim.verifyIntegrity()).toBeTrue();
+  });
+
+  it("requires a valid claimHashTree", () => {
+    const selfAttestedClaim = buildSelfAttestedClaim();
+    selfAttestedClaim.claimHashTree.full_name.hash = "0x0";
+
+    expect(selfAttestedClaim.verifyIntegrity()).toBeFalse();
+  });
+
+  it("requires a valid claimTypeHash", () => {
+    const selfAttestedClaim = buildSelfAttestedClaim();
+    selfAttestedClaim.claimTypeHash.hash = "0x0";
+
+    expect(selfAttestedClaim.verifyIntegrity()).toBeFalse();
+  });
+
+  it("requires a valid claimerAddress", () => {
+    const selfAttestedClaim = buildSelfAttestedClaim();
+    selfAttestedClaim.claimerAddress = "0x0";
+
+    expect(selfAttestedClaim.verifyIntegrity()).toBeFalse();
+  });
+
+  it("requires a valid rootHash", () => {
+    const selfAttestedClaim = buildSelfAttestedClaim();
+    selfAttestedClaim.rootHash = "0x0";
+
+    expect(selfAttestedClaim.verifyIntegrity()).toBeFalse();
+  });
+});
+
+describe("verifySignature", () => {
+  it("is true for a correctly signed selfAttestedClaim", async () => {
+    const attester = Wallet.createRandom();
+    const selfAttestedClaim = buildSelfAttestedClaim(attester.address);
+    const hash = selfAttestedClaim.generateHash();
+    selfAttestedClaim.attesterSignature = await attester.signMessage(hash);
+
+    expect(selfAttestedClaim.verifySignature()).toBeTrue();
+  });
+
+  it("requires a valid attesterSignature", async () => {
+    const attester = Wallet.createRandom();
+    const selfAttestedClaim = buildSelfAttestedClaim(attester.address);
+    const hash = "0x0";
+    selfAttestedClaim.attesterSignature = await attester.signMessage(hash);
+
+    expect(selfAttestedClaim.verifySignature()).toBeFalse();
+  });
+
+  it("requires a valid attesterAddress", async () => {
+    const attester = Wallet.createRandom();
+    const selfAttestedClaim = buildSelfAttestedClaim("0x0");
+    const hash = selfAttestedClaim.generateHash();
+    selfAttestedClaim.attesterSignature = await attester.signMessage(hash);
+
+    expect(selfAttestedClaim.verifySignature()).toBeFalse();
+  });
+});

--- a/src/AttestationRequest/index.ts
+++ b/src/AttestationRequest/index.ts
@@ -63,6 +63,15 @@ export default class Request implements IAttestationRequest {
     );
   }
 
+  public validateWithoutSignature(): boolean {
+    // ensure that all the validations always run
+    const validClaimHashTree = this.validateClaimHashTree();
+    const validClaimTypeHash = this.validateClaimTypeHash();
+    const validRootHash = this.validateRootHash();
+
+    return validClaimHashTree && validClaimTypeHash && validRootHash;
+  }
+
   public validateClaimerSignature(): boolean {
     if (!this.claimerSignature || !this.claim.owner) return false;
 

--- a/src/Claim/index.ts
+++ b/src/Claim/index.ts
@@ -9,12 +9,12 @@ export default class Claim implements IClaim {
   public constructor(
     claimType: IClaimType,
     properties: IClaimProperties,
-    owner: Address
+    owner?: Address
   ) {
     Validator.validate(claimType.schema, properties);
 
     this.claimTypeHash = claimType.hash;
-    this.owner = owner;
+    this.owner = owner || null;
     this.properties = Claim.pruneProperties(properties, claimType);
   }
 

--- a/src/ClaimType/index.ts
+++ b/src/ClaimType/index.ts
@@ -2,37 +2,25 @@ import type { IClaimPseudoSchema, IClaimType } from "../types";
 
 import Crypto from "../Crypto";
 
+import {
+  LivenessSchema,
+  BasicSchema,
+  PlusSchema,
+  WalletSchema,
+  CountryOfIDIssuanceKey,
+  CountryOfResidenceKey,
+} from "./schemas";
+
 const DEFAULT_SCHEMA_VERSION = "https://json-schema.org/draft/2020-12/schema";
 
 export default class ClaimType implements IClaimType {
-  public static LivenessSchema = {
-    liveness: { type: "boolean" },
-  };
+  public static LivenessSchema = LivenessSchema;
+  public static BasicSchema = BasicSchema;
+  public static PlusSchema = PlusSchema;
+  public static WalletSchema = WalletSchema;
 
-  public static BasicSchema = {
-    residential_address_country: { type: "string" },
-    date_of_birth: { type: "string" },
-    full_name: { type: "string" },
-    identification_document_country: { type: "string" },
-    identification_document_number: { type: "string" },
-    identification_document_type: { type: "string" },
-  };
-
-  public static PlusSchema = {
-    place_of_birth: { type: ["string", "null"] },
-    residential_address: { type: "string" },
-    residential_address_country: { type: "string" },
-    date_of_birth: { type: "string" },
-    full_name: { type: "string" },
-    identification_document_country: { type: "string" },
-    identification_document_number: { type: "string" },
-    identification_document_type: { type: "string" },
-  };
-
-  public static WalletSchema = {
-    wallet_address: { type: "string" },
-    wallet_currency: { type: "string" },
-  };
+  public static CountryOfIDIssuanceKey = CountryOfIDIssuanceKey;
+  public static CountryOfResidenceKey = CountryOfResidenceKey;
 
   public hash: IClaimType["hash"];
   public owner: IClaimType["owner"];

--- a/src/ClaimType/schemas.ts
+++ b/src/ClaimType/schemas.ts
@@ -1,0 +1,30 @@
+export const LivenessSchema = {
+  liveness: { type: "boolean" },
+};
+
+export const BasicSchema = {
+  residential_address_country: { type: "string" },
+  date_of_birth: { type: "string" },
+  full_name: { type: "string" },
+  identification_document_country: { type: "string" },
+  identification_document_number: { type: "string" },
+  identification_document_type: { type: "string" },
+};
+
+export const PlusSchema = {
+  place_of_birth: { type: ["string", "null"] },
+  residential_address: { type: "string" },
+  residential_address_country: { type: "string" },
+  date_of_birth: { type: "string" },
+  full_name: { type: "string" },
+  identification_document_country: { type: "string" },
+  identification_document_number: { type: "string" },
+  identification_document_type: { type: "string" },
+};
+
+export const WalletSchema = {
+  wallet_currency: { type: "string" },
+};
+
+export const CountryOfIDIssuanceKey = "identification_document_country";
+export const CountryOfResidenceKey = "residential_address_country";

--- a/src/FractalError/index.ts
+++ b/src/FractalError/index.ts
@@ -1,4 +1,4 @@
-import { IAttestationRequest, IAttestedClaim } from "../types";
+import { IAttestationRequest } from "../types";
 
 export default class FractalError extends Error {
   constructor(message: string) {

--- a/src/SelfAttestedClaim/CountryTiers.ts
+++ b/src/SelfAttestedClaim/CountryTiers.ts
@@ -1,0 +1,7 @@
+import { Byte } from "../types/Byte";
+
+const ToTier = (_country: string): Byte => new Byte(1);
+
+export default {
+  ToTier,
+};

--- a/src/SelfAttestedClaim/KYCTypes.ts
+++ b/src/SelfAttestedClaim/KYCTypes.ts
@@ -1,0 +1,7 @@
+import { Byte } from "../types/Byte";
+
+const ToByte = (_type: string): Byte => new Byte(1);
+
+export default {
+  ToByte,
+};

--- a/src/SelfAttestedClaim/index.ts
+++ b/src/SelfAttestedClaim/index.ts
@@ -1,0 +1,158 @@
+import AttestationRequest from "../AttestationRequest";
+import ClaimType from "../ClaimType";
+import Crypto from "../Crypto";
+import FractalError from "../FractalError";
+
+import CountryTiers from "./CountryTiers";
+import KYCTypes from "./KYCTypes";
+
+import { utils as ethersUtils } from "ethers";
+
+import {
+  IClaim,
+  ISelfAttestedClaim,
+  Hash,
+  Address,
+  Signature,
+  HashWithNonce,
+  HashTree,
+  Byte,
+} from "../types";
+
+export default class SelfAttestedClaim implements ISelfAttestedClaim {
+  public static fromRequest(
+    request: AttestationRequest,
+    attesterAddress: string,
+    kycLevel: string
+  ) {
+    if (!request.claim.owner || !request.validateWithoutSignature())
+      throw FractalError.attestedClaimFromInvalidRequest(request);
+
+    const { hash: expectedClaimTypeHash } = ClaimType.build(kycLevel);
+    const { claim, claimTypeHash, claimHashTree, rootHash } = request;
+
+    if (expectedClaimTypeHash !== claim.claimTypeHash)
+      throw FractalError.attestedClaimFromInvalidRequest(request);
+
+    const { owner, properties } = claim;
+    const claimerAddress = owner as string;
+
+    const countryOfIDIssuance = CountryTiers.ToTier(
+      properties[ClaimType.CountryOfIDIssuanceKey] as string
+    );
+
+    const countryOfResidence = CountryTiers.ToTier(
+      properties[ClaimType.CountryOfResidenceKey] as string
+    );
+
+    const kycType = KYCTypes.ToByte(kycLevel);
+
+    return new SelfAttestedClaim({
+      claim,
+      claimTypeHash,
+      claimHashTree,
+      rootHash,
+      claimerAddress,
+      attesterAddress,
+      attesterSignature: null,
+      countryOfIDIssuance,
+      countryOfResidence,
+      kycType,
+    });
+  }
+
+  public claim: IClaim;
+  public claimTypeHash: HashWithNonce;
+  public claimHashTree: HashTree;
+  public rootHash: Hash;
+  public claimerAddress: Address;
+  public attesterAddress: Address;
+  public attesterSignature: Signature | null;
+  public countryOfIDIssuance: Byte;
+  public countryOfResidence: Byte;
+  public kycType: Byte;
+
+  public constructor({
+    claim,
+    claimTypeHash,
+    claimHashTree,
+    rootHash,
+    claimerAddress,
+    attesterAddress,
+    attesterSignature,
+    countryOfIDIssuance,
+    countryOfResidence,
+    kycType,
+  }: ISelfAttestedClaim) {
+    this.claim = claim;
+    this.claimTypeHash = claimTypeHash;
+    this.claimHashTree = claimHashTree;
+    this.rootHash = rootHash;
+    this.claimerAddress = claimerAddress;
+    this.attesterAddress = attesterAddress;
+    this.attesterSignature = attesterSignature;
+    this.countryOfIDIssuance = countryOfIDIssuance;
+    this.countryOfResidence = countryOfResidence;
+    this.kycType = kycType;
+  }
+
+  public generateHash(): Hash {
+    return ethersUtils.solidityKeccak256(
+      ["string", "uint8", "uint8", "uint8", "string"],
+      [
+        this.claimerAddress,
+        this.kycType.value,
+        this.countryOfResidence.value,
+        this.countryOfIDIssuance.value,
+        this.rootHash,
+      ]
+    );
+  }
+
+  public verifyIntegrity(): boolean {
+    return (
+      this.verifyClaimHashTree() &&
+      this.verifyClaimTypeHash() &&
+      this.verifyClaimerAddress() &&
+      this.verifyRootHash()
+    );
+  }
+
+  public verifySignature(): boolean {
+    if (!this.attesterSignature || !this.attesterAddress) return false;
+
+    return Crypto.verifySignature(
+      this.attesterSignature,
+      this.generateHash(),
+      this.attesterAddress
+    );
+  }
+
+  private verifyClaimHashTree() {
+    return Crypto.verifyPartialClaimHashTree(
+      this.claimHashTree,
+      this.claim.properties,
+      this.claim.claimTypeHash
+    );
+  }
+
+  private verifyClaimTypeHash() {
+    return Crypto.verifyHashWithNonce(
+      this.claimTypeHash,
+      this.claim.claimTypeHash
+    );
+  }
+
+  private verifyClaimerAddress() {
+    return this.claim.owner === this.claimerAddress;
+  }
+
+  private verifyRootHash() {
+    return Crypto.verifyRootHash(
+      this.claimHashTree,
+      this.claimTypeHash.hash,
+      this.claimerAddress,
+      this.rootHash
+    );
+  }
+}

--- a/src/types/Byte.ts
+++ b/src/types/Byte.ts
@@ -1,0 +1,14 @@
+export class Byte {
+  private _value: Uint8Array;
+
+  public constructor(value: number) {
+    if (value < 0 || value > 254)
+      throw new TypeError(`Invalid Uint8 Value: ${value}`);
+
+    this._value = new Uint8Array([value]);
+  }
+
+  get value(): number {
+    return this._value[0];
+  }
+}

--- a/src/types/SelfAttestedClaim.ts
+++ b/src/types/SelfAttestedClaim.ts
@@ -1,0 +1,17 @@
+import { Address, Hash, Signature, HashWithNonce, HashTree } from "./base";
+
+import { Byte } from "./Byte";
+import { IClaim } from "./Claim";
+
+export interface ISelfAttestedClaim {
+  claim: IClaim;
+  claimTypeHash: HashWithNonce;
+  claimHashTree: HashTree;
+  rootHash: Hash;
+  claimerAddress: Address;
+  attesterAddress: Address;
+  attesterSignature: Signature | null;
+  countryOfIDIssuance: Byte;
+  countryOfResidence: Byte;
+  kycType: Byte;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,3 +4,6 @@ export * from "./AttestationRequest";
 export * from "./Claim";
 export * from "./ClaimType";
 export * from "./AttestedClaim";
+export * from "./SelfAttestedClaim";
+
+export * from "./Byte";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "outDir": "./build",
+    "target": "es5",
     "lib": ["es2017"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -389,6 +389,11 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
+"@types/node@^15.12.2":
+  version "15.12.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.12.2.tgz#1f2b42c4be7156ff4a6f914b2fb03d05fa84e38d"
+  integrity sha512-zjQ69G564OCIWIOHSXyQEEDpdpGl+G348RAKY0XXy9Z5kU9Vzv1GMNnkar/ZJ8dzXB3COzD9Mo9NtRZ4xfgUww==
+
 "@types/uuid@^8.3.0":
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.0.tgz#215c231dff736d5ba92410e6d602050cce7e273f"


### PR DESCRIPTION
These are claims that do not require a 2-party system to be correctly
generated. Essentially they place the trust on the attester that
everything will be correct and validated.

They require, however, additional security concerns to ensure that a
user does not generate credentials on behalf of a third user. This means
that these credentials are vulnerable to identity theft: the attester
will generate and attest a valid claim without relying on the
information that the claimer indeed owns the associated address. This
check should be ensured by the system that makes use of
SelfAttestedClaims.