### PR TITLE
Add selective disclosure to self attested claims

### DIFF
--- a/spec/integration/GenerateSelfAttestedClaimSpec.ts
+++ b/spec/integration/GenerateSelfAttestedClaimSpec.ts
@@ -55,5 +55,20 @@ describe("generate a self attested claim", () => {
     // signed
     expect(selfAttestedClaim.verifyIntegrity()).toBeTrue();
     expect(selfAttestedClaim.verifySignature()).toBeTrue();
+
+    // Remove the property from the selfAttestedClaim
+    selfAttestedClaim.removeProperty("full_name");
+
+    expect(selfAttestedClaim.getProperty("residential_address_country"));
+    expect(selfAttestedClaim.getProperty("date_of_birth"));
+    expect(selfAttestedClaim.getProperty("full_name"));
+    expect(selfAttestedClaim.getProperty("identification_document_country"));
+    expect(selfAttestedClaim.getProperty("identification_document_number"));
+    expect(selfAttestedClaim.getProperty("identification_document_type"));
+    expect(selfAttestedClaim.getProperty("liveness"));
+    expect(selfAttestedClaim.getProperty("full_name")).not.toBeDefined();
+
+    // Ensure the integrity of data
+    expect(selfAttestedClaim.verifyIntegrity()).toBeTrue();
   });
 });

--- a/spec/unit/SelfAttestedClaim/SelfAttestedClaimSpec.ts
+++ b/spec/unit/SelfAttestedClaim/SelfAttestedClaimSpec.ts
@@ -162,3 +162,49 @@ describe("verifySignature", () => {
     expect(selfAttestedClaim.verifySignature()).toBeFalse();
   });
 });
+
+describe("removeProperty", () => {
+  it("deletes the property and the corresponding nonce", () => {
+    // const selfAttestedClaim = buildSelfAttestedClaim();
+    const claimerAddress = "0x0";
+    const attesterAddress = "0x1";
+    const claimTypeHash = { hash: "0x123", nonce: "0x0" };
+
+    const claimHashTree = {
+      full_name: { hash: "0x1", nonce: "0x2" },
+      date_of_birth: { hash: "0x3", nonce: "0x4" },
+    };
+
+    const claim = {
+      claimTypeHash: claimTypeHash.hash,
+      owner: claimerAddress,
+      properties: {
+        full_name: "JOHN CITIZEN",
+        date_of_birth: "1990-01-01",
+      },
+    };
+
+    const selfAttestedClaim = new SelfAttestedClaim({
+      claim,
+      claimTypeHash,
+      claimHashTree,
+      rootHash: "0x0",
+      claimerAddress,
+      attesterAddress,
+      attesterSignature: null,
+      countryOfIDIssuance: new Byte(1),
+      countryOfResidence: new Byte(1),
+      kycType: new Byte(1),
+    });
+
+    selfAttestedClaim.removeProperty("date_of_birth");
+
+    expect(selfAttestedClaim.claim.properties).toEqual({
+      full_name: "JOHN CITIZEN",
+    });
+    expect(selfAttestedClaim.claimHashTree).toEqual({
+      full_name: { hash: "0x1", nonce: "0x2" },
+      date_of_birth: { hash: "0x3" },
+    });
+  });
+});

--- a/spec/unit/SelfAttestedClaim/SelfAttestedClaimSpec.ts
+++ b/spec/unit/SelfAttestedClaim/SelfAttestedClaimSpec.ts
@@ -165,7 +165,6 @@ describe("verifySignature", () => {
 
 describe("removeProperty", () => {
   it("deletes the property and the corresponding nonce", () => {
-    // const selfAttestedClaim = buildSelfAttestedClaim();
     const claimerAddress = "0x0";
     const attesterAddress = "0x1";
     const claimTypeHash = { hash: "0x123", nonce: "0x0" };

--- a/src/SelfAttestedClaim/index.ts
+++ b/src/SelfAttestedClaim/index.ts
@@ -109,6 +109,15 @@ export default class SelfAttestedClaim implements ISelfAttestedClaim {
     );
   }
 
+  public removeProperty(property: string): void {
+    delete this.claim.properties[property];
+    delete this.claimHashTree[property]["nonce"];
+  }
+
+  public getProperty(property: string): any {
+    return this.claim.properties[property];
+  }
+
   public verifyIntegrity(): boolean {
     return (
       this.verifyClaimHashTree() &&


### PR DESCRIPTION
This PR adds the `removeProperty` method to `SelfAttestedClaims` needed for selective disclosure.