### PR TITLE
Fix hash generation to match solidity

### DIFF
--- a/spec/integration/GenerateSelfAttestedClaimSpec.ts
+++ b/spec/integration/GenerateSelfAttestedClaimSpec.ts
@@ -1,5 +1,5 @@
 import "jasmine";
-import { Wallet } from "ethers";
+import { Wallet, utils as ethersUtils } from "ethers";
 
 import AttestationRequest from "../../src/AttestationRequest";
 import Claim from "../../src/Claim";
@@ -10,7 +10,7 @@ describe("generate a self attested claim", () => {
   it("results in a valid SelfAttestedClaim", async () => {
     const attester = Wallet.createRandom();
     const claimer = Wallet.createRandom();
-    const kycLevel = "basic+liveness";
+    const kycLevel = "basic+liveness+wallet";
 
     // Generate a claim type
     const claimType = ClaimType.build(kycLevel);
@@ -24,6 +24,8 @@ describe("generate a self attested claim", () => {
       identification_document_number: "00000000",
       identification_document_type: "passport",
       liveness: true,
+      wallet_currency: "ETH",
+      wallet_address: claimer.address,
     };
 
     const claim = new Claim(claimType, properties, claimer.address);
@@ -48,7 +50,7 @@ describe("generate a self attested claim", () => {
     // Generate the hash and sign it
     const hashToSign = selfAttestedClaim.generateHash();
     selfAttestedClaim.attesterSignature = await attester.signMessage(
-      hashToSign
+      ethersUtils.arrayify(hashToSign)
     );
 
     // Run the expectations: the claim has complete integrity and is correctly

--- a/spec/unit/SelfAttestedClaim/SelfAttestedClaimSpec.ts
+++ b/spec/unit/SelfAttestedClaim/SelfAttestedClaimSpec.ts
@@ -1,5 +1,5 @@
 import "jasmine";
-import { Wallet } from "ethers";
+import { Wallet, utils as ethersUtils } from "ethers";
 
 import AttestationRequest from "../../../src/AttestationRequest";
 import Claim from "../../../src/Claim";
@@ -139,7 +139,9 @@ describe("verifySignature", () => {
     const attester = Wallet.createRandom();
     const selfAttestedClaim = buildSelfAttestedClaim(attester.address);
     const hash = selfAttestedClaim.generateHash();
-    selfAttestedClaim.attesterSignature = await attester.signMessage(hash);
+    selfAttestedClaim.attesterSignature = await attester.signMessage(
+      ethersUtils.arrayify(hash)
+    );
 
     expect(selfAttestedClaim.verifySignature()).toBeTrue();
   });

--- a/src/ClaimType/schemas.ts
+++ b/src/ClaimType/schemas.ts
@@ -23,6 +23,7 @@ export const PlusSchema = {
 };
 
 export const WalletSchema = {
+  wallet_address: { type: "string" },
   wallet_currency: { type: "string" },
 };
 

--- a/src/SelfAttestedClaim/index.ts
+++ b/src/SelfAttestedClaim/index.ts
@@ -98,7 +98,7 @@ export default class SelfAttestedClaim implements ISelfAttestedClaim {
 
   public generateHash(): Hash {
     return ethersUtils.solidityKeccak256(
-      ["string", "uint8", "uint8", "uint8", "string"],
+      ["address", "uint8", "uint8", "uint8", "bytes32"],
       [
         this.claimerAddress,
         this.kycType.value,
@@ -132,7 +132,7 @@ export default class SelfAttestedClaim implements ISelfAttestedClaim {
 
     return Crypto.verifySignature(
       this.attesterSignature,
-      this.generateHash(),
+      ethersUtils.arrayify(this.generateHash()),
       this.attesterAddress
     );
   }


### PR DESCRIPTION
Why:

* The sample contract we're giving out to verify self attested claims
  was generating different hashes.

This change addresses the need by:

* Fixing a lot of small errors, including wrongful data types and not
  arrayifying the signature before signing it.